### PR TITLE
Kenny/feat depends

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,5 @@ name = "hardware_report" # Optional, defaults to the package name
 path = "src/lib.rs"      # Path to the library file
 
 [[bin]]
-name = "hardware_report_binary" # Name of the binary
-path = "src/bin/hardware_report.rs"         # Path to the binary's main.rs
+name = "hardware_report"            # Name of the binary
+path = "src/bin/hardware_report.rs" # Path to the binary's main.rs


### PR DESCRIPTION

**Makefile: Conditional Docker Usage & Numactl Install**

---


**Changes:**
1. Use Docker for cross-compiling Linux binaries only if on macOS, Docker is installed, and running.
2. Add `numactl` installation check on Linux in `install-tools` to ensure system compatibility.

**Why:**
- Prevent failures on macOS when Docker isn't running.
- Ensure `numactl` is available for proper hardware reporting on Linux.