### PR TITLE
fix: add dmidecode to Nix runtime dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
           ethtool
           util-linux  # for lscpu
           pciutils    # for lspci
+          dmidecode   # for system/BIOS/memory information
         ];
         
         hardware_report_unwrapped = pkgs.rustPlatform.buildRustPackage {
@@ -108,7 +109,7 @@ Maintainer: Kenny Sheridan <kenny@sfcompute.com>
 Description: Hardware information collection tool
  A tool for generating detailed hardware information reports from Linux servers,
  outputting the data in TOML format for infrastructure standardization.
-Depends: numactl, ipmitool, ethtool, util-linux, pciutils
+Depends: numactl, ipmitool, ethtool, util-linux, pciutils, dmidecode
 Priority: optional
 Section: utils
 EOF
@@ -255,7 +256,7 @@ EOF
             echo "Run 'cargo run' to run the project"
             echo ""
             echo "Runtime dependencies are available in PATH:"
-            echo "- numactl, ipmitool, ethtool, lscpu, lspci"
+            echo "- numactl, ipmitool, ethtool, lscpu, lspci, dmidecode"
           '';
         };
         


### PR DESCRIPTION
## Summary
- Add dmidecode to Nix flake runtime dependencies to fix missing utility error on NixOS systems

## Test plan
- [ ] Build the Nix package with `nix build`
- [ ] Run `sudo ./result/bin/hardware_report` and verify no dmidecode warnings appear
- [ ] Verify system UUID, serial numbers, and memory information are properly collected