### PR TITLE
docs: add direct Nix flake installation option and fix Darwin compatibility

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,2 @@
+export DIRENV_LOG_FORMAT=""
 use flake

--- a/README.md
+++ b/README.md
@@ -180,7 +180,27 @@ echo "Build complete! Run with: sudo ./target/release/hardware_report" && \
 sudo ./target/release/hardware_report
 ```
 
-### Option 3: Pre-built Releases (Recommended for Quick Setup)
+### Option 3: Direct Flake Installation (Nix Users)
+
+**Install directly from GitHub without cloning:**
+```bash
+# Install to user profile
+nix profile install github:sfcompute/hardware_report
+
+# Run directly without installing
+nix run github:sfcompute/hardware_report
+
+# Use in a nix shell
+nix shell github:sfcompute/hardware_report
+```
+
+**Benefits:**
+- No need to clone the repository
+- Always uses the latest committed version
+- Automatic dependency management
+- Clean integration with existing Nix workflows
+
+### Option 4: Pre-built Releases (Recommended for Quick Setup)
 
 Instead of building from source, you can download pre-built binaries and Debian packages from our [GitHub Releases](https://github.com/sfcompute/hardware_report/releases) page.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,13 +35,16 @@ use std::collections::{HashMap, HashSet};
 use std::error::Error;
 use std::process::Command;
 
+pub mod posting;
+pub mod netbox;
+
 lazy_static! {
     static ref STORAGE_SIZE_RE: Regex = Regex::new(r"(\d+(?:\.\d+)?)(B|K|M|G|T)").unwrap();
     static ref NETWORK_SPEED_RE: Regex = Regex::new(r"Speed:\s+(\S+)").unwrap();
 }
 
 /// CPU topology information
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CpuTopology {
     pub total_cores: u32,
     pub total_threads: u32,
@@ -53,7 +56,7 @@ pub struct CpuTopology {
 }
 
 /// Motherboard information
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MotherboardInfo {
     pub manufacturer: String,
     pub product_name: String,
@@ -64,7 +67,7 @@ pub struct MotherboardInfo {
     pub type_: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SystemInfo {
     pub uuid: String,
     pub serial: String,
@@ -73,7 +76,7 @@ pub struct SystemInfo {
 }
 
 /// Summary of key system components
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SystemSummary {
     /// System information
     pub system_info: SystemInfo,
@@ -106,7 +109,7 @@ pub struct SystemSummary {
 }
 
 /// BIOS information
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BiosInfo {
     pub vendor: String,
     pub version: String,
@@ -115,7 +118,7 @@ pub struct BiosInfo {
 }
 
 /// Chassis information
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChassisInfo {
     pub manufacturer: String,
     pub type_: String,
@@ -123,7 +126,7 @@ pub struct ChassisInfo {
 }
 
 /// Represents the overall server information
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerInfo {
     /// System summary
     pub summary: SystemSummary,
@@ -138,7 +141,7 @@ pub struct ServerInfo {
 }
 
 /// Contains detailed hardware information
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HardwareInfo {
     /// CPU information.
     pub cpu: CpuInfo,
@@ -151,7 +154,7 @@ pub struct HardwareInfo {
 }
 
 /// Represents CPU information.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CpuInfo {
     /// CPU model name.
     pub model: String,
@@ -166,7 +169,7 @@ pub struct CpuInfo {
 }
 
 /// Represents memory information.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryInfo {
     /// Total memory size.
     pub total: String,
@@ -179,7 +182,7 @@ pub struct MemoryInfo {
 }
 
 /// Represents a memory module.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryModule {
     /// Size of the memory module.
     pub size: String,
@@ -196,14 +199,14 @@ pub struct MemoryModule {
 }
 
 /// Represents storage information.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageInfo {
     /// List of storage devices.
     pub devices: Vec<StorageDevice>,
 }
 
 /// Represents a storage device.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StorageDevice {
     /// Device name.
     pub name: String,
@@ -216,14 +219,14 @@ pub struct StorageDevice {
 }
 
 /// Represents GPU information.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GpuInfo {
     /// List of GPU devices.
     pub devices: Vec<GpuDevice>,
 }
 
 /// Represents a GPU device.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GpuDevice {
     /// GPU index
     pub index: u32,
@@ -242,7 +245,7 @@ pub struct GpuDevice {
 }
 
 /// Represents a NUMA node
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NumaNode {
     /// Node ID
     pub id: i32,
@@ -257,7 +260,7 @@ pub struct NumaNode {
 }
 
 /// Represents a device attached to a NUMA node
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NumaDevice {
     /// Device type (GPU, NIC, etc.)
     pub type_: String,
@@ -268,7 +271,7 @@ pub struct NumaDevice {
 }
 
 /// Represents network information.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkInfo {
     /// List of network interfaces.
     pub interfaces: Vec<NetworkInterface>,
@@ -277,7 +280,7 @@ pub struct NetworkInfo {
 }
 
 /// Represents a network interface.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkInterface {
     /// Interface name.
     pub name: String,
@@ -296,14 +299,14 @@ pub struct NetworkInterface {
 }
 
 /// Represents Infiniband information.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InfinibandInfo {
     /// List of Infiniband interfaces.
     pub interfaces: Vec<IbInterface>,
 }
 
 /// Represents an Infiniband interface.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IbInterface {
     /// Interface name.
     pub name: String,
@@ -320,9 +323,7 @@ pub struct NumaInfo {
     pub nodes: Vec<NumaNode>,
 }
 
-pub mod posting;
-
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InterfaceIPs {
     pub interface: String,
     pub ip_addresses: Vec<String>,

--- a/src/netbox.rs
+++ b/src/netbox.rs
@@ -1,0 +1,969 @@
+/*
+Copyright 2024 San Francisco Compute Company
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+use crate::ServerInfo;
+use reqwest;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum NetBoxError {
+    ApiError(String),
+    ConnectionError(String),
+    ValidationError(String),
+}
+
+impl fmt::Display for NetBoxError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            NetBoxError::ApiError(msg) => write!(f, "NetBox API error: {}", msg),
+            NetBoxError::ConnectionError(msg) => write!(f, "Connection error: {}", msg),
+            NetBoxError::ValidationError(msg) => write!(f, "Validation error: {}", msg),
+        }
+    }
+}
+
+impl Error for NetBoxError {}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetBoxDevice {
+    pub name: String,
+    pub device_type: u32, // ID of the device type
+    pub device_role: u32, // ID of the device role
+    pub platform: Option<u32>, // ID of the platform
+    pub serial: String,
+    pub asset_tag: Option<String>,
+    pub site: u32, // ID of the site
+    pub rack: Option<u32>, // ID of the rack
+    pub position: Option<f32>,
+    pub face: Option<String>, // "front" or "rear"
+    pub status: String, // "active", "planned", "staged", etc.
+    pub airflow: Option<String>, // "front-to-rear", "rear-to-front", etc.
+    pub primary_ip4: Option<u32>, // ID of primary IPv4
+    pub primary_ip6: Option<u32>, // ID of primary IPv6
+    pub cluster: Option<u32>, // ID of cluster
+    pub virtual_chassis: Option<u32>,
+    pub vc_position: Option<u32>,
+    pub vc_priority: Option<u32>,
+    pub description: Option<String>,
+    pub comments: Option<String>,
+    pub config_template: Option<u32>,
+    pub local_context_data: Option<HashMap<String, serde_json::Value>>,
+    pub tags: Option<Vec<u32>>,
+    pub custom_fields: Option<HashMap<String, serde_json::Value>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetBoxDeviceType {
+    pub manufacturer: u32, // ID of manufacturer
+    pub model: String,
+    pub slug: String,
+    pub part_number: Option<String>,
+    pub u_height: f32, // Height in rack units (4.0 for Digital Ocean nodes)
+    pub is_full_depth: bool,
+    pub subdevice_role: Option<String>, // "parent", "child", or null
+    pub airflow: Option<String>,
+    pub front_image: Option<String>,
+    pub rear_image: Option<String>,
+    pub description: Option<String>,
+    pub comments: Option<String>,
+    pub tags: Option<Vec<u32>>,
+    pub custom_fields: Option<HashMap<String, serde_json::Value>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetBoxInterface {
+    pub device: u32, // ID of the device
+    pub name: String,
+    pub type_: String, // Interface type (e.g., "1000base-t", "10gbase-x-sfpp")
+    pub enabled: bool,
+    pub parent: Option<u32>, // Parent interface ID
+    pub bridge: Option<u32>, // Bridge interface ID
+    pub lag: Option<u32>, // LAG interface ID
+    pub mtu: Option<u32>,
+    pub mac_address: Option<String>,
+    pub speed: Option<u32>, // Speed in Kbps
+    pub duplex: Option<String>, // "auto", "full", "half"
+    pub wwn: Option<String>,
+    pub mgmt_only: bool, // True for out-of-band management interfaces
+    pub description: Option<String>,
+    pub mode: Option<String>, // "access", "tagged", "tagged-all"
+    pub rf_role: Option<String>,
+    pub rf_channel: Option<String>,
+    pub poe_mode: Option<String>,
+    pub poe_type: Option<String>,
+    pub rf_channel_frequency: Option<f32>,
+    pub rf_channel_width: Option<f32>,
+    pub tx_power: Option<u32>,
+    pub untagged_vlan: Option<u32>,
+    pub tagged_vlans: Option<Vec<u32>>,
+    pub mark_connected: bool,
+    pub cable: Option<u32>,
+    pub cable_end: Option<String>,
+    pub wireless_link: Option<u32>,
+    pub link_peers: Option<Vec<HashMap<String, serde_json::Value>>>,
+    pub link_peers_type: Option<String>,
+    pub wireless_lans: Option<Vec<u32>>,
+    pub vrf: Option<u32>,
+    pub tags: Option<Vec<u32>>,
+    pub custom_fields: Option<HashMap<String, serde_json::Value>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetBoxIPAddress {
+    pub address: String, // IP address in CIDR notation (e.g., "192.168.1.1/24")
+    pub vrf: Option<u32>, // VRF ID
+    pub tenant: Option<u32>, // Tenant ID
+    pub status: String, // "active", "reserved", "deprecated", "dhcp", "slaac"
+    pub role: Option<String>, // "loopback", "secondary", "anycast", "vip", "vrrp", "hsrp", "glbp", "carp"
+    pub assigned_object_type: Option<String>, // "dcim.interface" or "virtualization.vminterface"
+    pub assigned_object_id: Option<u32>, // ID of the interface
+    pub nat_inside: Option<u32>, // ID of NAT inside IP
+    pub nat_outside: Option<Vec<u32>>, // IDs of NAT outside IPs
+    pub dns_name: Option<String>,
+    pub description: Option<String>,
+    pub comments: Option<String>,
+    pub tags: Option<Vec<u32>>,
+    pub custom_fields: Option<HashMap<String, serde_json::Value>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetBoxInventoryItem {
+    pub device: u32, // Device ID
+    pub parent: Option<u32>, // Parent inventory item ID
+    pub name: String,
+    pub label: Option<String>,
+    pub role: Option<u32>, // Inventory item role ID
+    pub manufacturer: Option<u32>, // Manufacturer ID
+    pub part_id: Option<String>,
+    pub serial: Option<String>,
+    pub asset_tag: Option<String>,
+    pub discovered: bool,
+    pub description: Option<String>,
+    pub component_type: Option<String>,
+    pub component_id: Option<u32>,
+    pub tags: Option<Vec<u32>>,
+    pub custom_fields: Option<HashMap<String, serde_json::Value>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetBoxSite {
+    pub name: String,
+    pub slug: String,
+    pub status: String, // "active", "planned", "retired"
+    pub region: Option<u32>, // Region ID
+    pub group: Option<u32>, // Site group ID
+    pub tenant: Option<u32>, // Tenant ID
+    pub facility: Option<String>,
+    pub asns: Option<Vec<u32>>, // ASN IDs
+    pub time_zone: Option<String>,
+    pub description: Option<String>,
+    pub physical_address: Option<String>,
+    pub shipping_address: Option<String>,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
+    pub comments: Option<String>,
+    pub tags: Option<Vec<u32>>,
+    pub custom_fields: Option<HashMap<String, serde_json::Value>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct NetBoxCluster {
+    pub name: String,
+    pub type_: u32, // Cluster type ID
+    pub group: Option<u32>, // Cluster group ID
+    pub tenant: Option<u32>, // Tenant ID
+    pub site: Option<u32>, // Site ID
+    pub status: String, // "planned", "staging", "active", "decommissioning", "offline"
+    pub description: Option<String>,
+    pub comments: Option<String>,
+    pub tags: Option<Vec<u32>>,
+    pub custom_fields: Option<HashMap<String, serde_json::Value>>,
+}
+
+pub struct NetBoxClient {
+    base_url: String,
+    token: String,
+    client: reqwest::Client,
+}
+
+impl NetBoxClient {
+    pub fn new(base_url: String, token: String, skip_tls_verify: bool) -> Result<Self, Box<dyn Error>> {
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(skip_tls_verify)
+            .build()?;
+        
+        Ok(NetBoxClient {
+            base_url,
+            token,
+            client,
+        })
+    }
+
+    pub async fn get_or_create_site(&self, name: &str, slug: &str) -> Result<u32, Box<dyn Error>> {
+        // First try to find existing site
+        let search_url = format!("{}/api/dcim/sites/?slug={}", self.base_url, slug);
+        let response = self.client
+            .get(&search_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .send()
+            .await?;
+        
+        let data: serde_json::Value = response.json().await?;
+        if let Some(results) = data["results"].as_array() {
+            if !results.is_empty() {
+                if let Some(id) = results[0]["id"].as_u64() {
+                    return Ok(id as u32);
+                }
+            }
+        }
+        
+        // Create new site if not found
+        let site = NetBoxSite {
+            name: name.to_string(),
+            slug: slug.to_string(),
+            status: "active".to_string(),
+            region: None,
+            group: None,
+            tenant: None,
+            facility: None,
+            asns: None,
+            time_zone: None,
+            description: Some("Digital Ocean site".to_string()),
+            physical_address: None,
+            shipping_address: None,
+            latitude: None,
+            longitude: None,
+            comments: None,
+            tags: None,
+            custom_fields: None,
+        };
+        
+        let create_url = format!("{}/api/dcim/sites/", self.base_url);
+        let response = self.client
+            .post(&create_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .json(&site)
+            .send()
+            .await?;
+        
+        if !response.status().is_success() {
+            return Err(format!("Failed to create site: {}", response.status()).into());
+        }
+        
+        let created: serde_json::Value = response.json().await?;
+        if let Some(id) = created["id"].as_u64() {
+            Ok(id as u32)
+        } else {
+            Err("Failed to get site ID".into())
+        }
+    }
+
+    pub async fn get_or_create_manufacturer(&self, name: &str) -> Result<u32, Box<dyn Error>> {
+        // First try to find existing manufacturer
+        let search_url = format!("{}/api/dcim/manufacturers/?name={}", self.base_url, name);
+        let response = self.client
+            .get(&search_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .send()
+            .await?;
+        
+        let data: serde_json::Value = response.json().await?;
+        if let Some(results) = data["results"].as_array() {
+            if !results.is_empty() {
+                if let Some(id) = results[0]["id"].as_u64() {
+                    return Ok(id as u32);
+                }
+            }
+        }
+        
+        // Create new manufacturer if not found
+        let manufacturer = serde_json::json!({
+            "name": name,
+            "slug": name.to_lowercase().replace(" ", "-").replace(".", "")
+        });
+        
+        let create_url = format!("{}/api/dcim/manufacturers/", self.base_url);
+        let response = self.client
+            .post(&create_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .json(&manufacturer)
+            .send()
+            .await?;
+        
+        if !response.status().is_success() {
+            return Err(format!("Failed to create manufacturer: {}", response.status()).into());
+        }
+        
+        let created: serde_json::Value = response.json().await?;
+        if let Some(id) = created["id"].as_u64() {
+            Ok(id as u32)
+        } else {
+            Err("Failed to get manufacturer ID".into())
+        }
+    }
+
+    pub async fn get_or_create_device_type(&self, manufacturer_id: u32, model: &str, u_height: f32) -> Result<u32, Box<dyn Error>> {
+        // First try to find existing device type
+        let slug = model.to_lowercase().replace(" ", "-");
+        let search_url = format!("{}/api/dcim/device-types/?manufacturer_id={}&model={}", self.base_url, manufacturer_id, model);
+        let response = self.client
+            .get(&search_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .send()
+            .await?;
+        
+        let data: serde_json::Value = response.json().await?;
+        if let Some(results) = data["results"].as_array() {
+            if !results.is_empty() {
+                if let Some(id) = results[0]["id"].as_u64() {
+                    return Ok(id as u32);
+                }
+            }
+        }
+        
+        // Create new device type if not found
+        let device_type = NetBoxDeviceType {
+            manufacturer: manufacturer_id,
+            model: model.to_string(),
+            slug,
+            part_number: None,
+            u_height,
+            is_full_depth: true,
+            subdevice_role: None,
+            airflow: Some("front-to-rear".to_string()),
+            front_image: None,
+            rear_image: None,
+            description: None,
+            comments: None,
+            tags: None,
+            custom_fields: None,
+        };
+        
+        let create_url = format!("{}/api/dcim/device-types/", self.base_url);
+        let response = self.client
+            .post(&create_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .json(&device_type)
+            .send()
+            .await?;
+        
+        if !response.status().is_success() {
+            return Err(format!("Failed to create device type: {}", response.status()).into());
+        }
+        
+        let created: serde_json::Value = response.json().await?;
+        if let Some(id) = created["id"].as_u64() {
+            Ok(id as u32)
+        } else {
+            Err("Failed to get device type ID".into())
+        }
+    }
+
+    pub async fn get_or_create_device_role(&self, name: &str) -> Result<u32, Box<dyn Error>> {
+        // First try to find existing device role
+        let search_url = format!("{}/api/dcim/device-roles/?name={}", self.base_url, name);
+        let response = self.client
+            .get(&search_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .send()
+            .await?;
+        
+        let data: serde_json::Value = response.json().await?;
+        if let Some(results) = data["results"].as_array() {
+            if !results.is_empty() {
+                if let Some(id) = results[0]["id"].as_u64() {
+                    return Ok(id as u32);
+                }
+            }
+        }
+        
+        // Create new device role if not found
+        let role = serde_json::json!({
+            "name": name,
+            "slug": name.to_lowercase(),
+            "color": "0066cc"
+        });
+        
+        let create_url = format!("{}/api/dcim/device-roles/", self.base_url);
+        let response = self.client
+            .post(&create_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .json(&role)
+            .send()
+            .await?;
+        
+        if !response.status().is_success() {
+            return Err(format!("Failed to create device role: {}", response.status()).into());
+        }
+        
+        let created: serde_json::Value = response.json().await?;
+        if let Some(id) = created["id"].as_u64() {
+            Ok(id as u32)
+        } else {
+            Err("Failed to get device role ID".into())
+        }
+    }
+
+    pub async fn find_device_by_serial(&self, serial: &str) -> Result<Option<u32>, Box<dyn Error>> {
+        let search_url = format!("{}/api/dcim/devices/?serial={}", self.base_url, serial);
+        let response = self.client
+            .get(&search_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .send()
+            .await?;
+        
+        let data: serde_json::Value = response.json().await?;
+        if let Some(results) = data["results"].as_array() {
+            if !results.is_empty() {
+                if let Some(id) = results[0]["id"].as_u64() {
+                    return Ok(Some(id as u32));
+                }
+            }
+        }
+        
+        Ok(None)
+    }
+
+    pub async fn create_or_update_device(&self, device: &NetBoxDevice) -> Result<u32, Box<dyn Error>> {
+        // Check if device exists by serial number
+        if let Some(device_id) = self.find_device_by_serial(&device.serial).await? {
+            // Update existing device
+            let update_url = format!("{}/api/dcim/devices/{}/", self.base_url, device_id);
+            let response = self.client
+                .patch(&update_url)
+                .header("Authorization", format!("Token {}", self.token))
+                .json(&device)
+                .send()
+                .await?;
+            
+            if !response.status().is_success() {
+                return Err(format!("Failed to update device: {}", response.status()).into());
+            }
+            
+            Ok(device_id)
+        } else {
+            // Create new device
+            let create_url = format!("{}/api/dcim/devices/", self.base_url);
+            let response = self.client
+                .post(&create_url)
+                .header("Authorization", format!("Token {}", self.token))
+                .json(&device)
+                .send()
+                .await?;
+            
+            if !response.status().is_success() {
+                return Err(format!("Failed to create device: {}", response.status()).into());
+            }
+            
+            let created: serde_json::Value = response.json().await?;
+            if let Some(id) = created["id"].as_u64() {
+                Ok(id as u32)
+            } else {
+                Err("Failed to get device ID".into())
+            }
+        }
+    }
+
+    pub async fn create_interface(&self, interface: &NetBoxInterface) -> Result<u32, Box<dyn Error>> {
+        let create_url = format!("{}/api/dcim/interfaces/", self.base_url);
+        let response = self.client
+            .post(&create_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .json(&interface)
+            .send()
+            .await?;
+        
+        if !response.status().is_success() {
+            return Err(format!("Failed to create interface: {}", response.status()).into());
+        }
+        
+        let created: serde_json::Value = response.json().await?;
+        if let Some(id) = created["id"].as_u64() {
+            Ok(id as u32)
+        } else {
+            Err("Failed to get interface ID".into())
+        }
+    }
+
+    pub async fn create_ip_address(&self, ip: &NetBoxIPAddress) -> Result<u32, Box<dyn Error>> {
+        let create_url = format!("{}/api/ipam/ip-addresses/", self.base_url);
+        let response = self.client
+            .post(&create_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .json(&ip)
+            .send()
+            .await?;
+        
+        if !response.status().is_success() {
+            return Err(format!("Failed to create IP address: {}", response.status()).into());
+        }
+        
+        let created: serde_json::Value = response.json().await?;
+        if let Some(id) = created["id"].as_u64() {
+            Ok(id as u32)
+        } else {
+            Err("Failed to get IP address ID".into())
+        }
+    }
+
+    pub async fn create_inventory_item(&self, item: &NetBoxInventoryItem) -> Result<u32, Box<dyn Error>> {
+        let create_url = format!("{}/api/dcim/inventory-items/", self.base_url);
+        let response = self.client
+            .post(&create_url)
+            .header("Authorization", format!("Token {}", self.token))
+            .json(&item)
+            .send()
+            .await?;
+        
+        if !response.status().is_success() {
+            return Err(format!("Failed to create inventory item: {}", response.status()).into());
+        }
+        
+        let created: serde_json::Value = response.json().await?;
+        if let Some(id) = created["id"].as_u64() {
+            Ok(id as u32)
+        } else {
+            Err("Failed to get inventory item ID".into())
+        }
+    }
+}
+
+pub async fn sync_to_netbox(
+    server_info: &ServerInfo,
+    netbox_url: &str,
+    token: &str,
+    site_name: Option<&str>,
+    device_role: Option<&str>,
+    skip_tls_verify: bool,
+    dry_run: bool,
+) -> Result<(), Box<dyn Error>> {
+    let client = NetBoxClient::new(netbox_url.to_string(), token.to_string(), skip_tls_verify)?;
+    
+    // Use provided site name or default to "digital-ocean"
+    let site = site_name.unwrap_or("Digital Ocean");
+    let site_slug = site.to_lowercase().replace(" ", "-");
+    let site_id = client.get_or_create_site(site, &site_slug).await?;
+    
+    // Get or create manufacturer
+    let manufacturer = &server_info.summary.system_info.product_manufacturer;
+    let manufacturer_id = client.get_or_create_manufacturer(manufacturer).await?;
+    
+    // Get or create device type with 4U height for Digital Ocean nodes
+    let model = &server_info.summary.system_info.product_name;
+    let device_type_id = client.get_or_create_device_type(manufacturer_id, model, 4.0).await?;
+    
+    // Get or create device role
+    let role = device_role.unwrap_or("production");
+    let device_role_id = client.get_or_create_device_role(role).await?;
+    
+    // Create custom fields for additional hardware info
+    let mut custom_fields = HashMap::new();
+    custom_fields.insert("bios_version".to_string(), serde_json::Value::String(server_info.summary.bios.version.clone()));
+    custom_fields.insert("bios_vendor".to_string(), serde_json::Value::String(server_info.summary.bios.vendor.clone()));
+    custom_fields.insert("cpu_model".to_string(), serde_json::Value::String(server_info.summary.cpu_topology.cpu_model.clone()));
+    custom_fields.insert("cpu_cores".to_string(), serde_json::Value::Number(server_info.summary.cpu_topology.total_cores.into()));
+    custom_fields.insert("cpu_threads".to_string(), serde_json::Value::Number(server_info.summary.cpu_topology.total_threads.into()));
+    custom_fields.insert("numa_nodes".to_string(), serde_json::Value::Number(server_info.summary.cpu_topology.numa_nodes.into()));
+    custom_fields.insert("total_memory".to_string(), serde_json::Value::String(server_info.summary.total_memory.clone()));
+    custom_fields.insert("total_storage".to_string(), serde_json::Value::String(server_info.summary.total_storage.clone()));
+    
+    // Create or update device
+    let device = NetBoxDevice {
+        name: server_info.fqdn.clone(),
+        device_type: device_type_id,
+        device_role: device_role_id,
+        platform: None,
+        serial: server_info.summary.chassis.serial.clone(),
+        asset_tag: None,
+        site: site_id,
+        rack: None,
+        position: None,
+        face: Some("front".to_string()),
+        status: "active".to_string(),
+        airflow: Some("front-to-rear".to_string()),
+        primary_ip4: None, // Will be set after creating IPs
+        primary_ip6: None,
+        cluster: None,
+        virtual_chassis: None,
+        vc_position: None,
+        vc_priority: None,
+        description: Some(format!("{} @ {}", model, site)),
+        comments: Some(format!("Auto-imported by hardware_report\nUUID: {}", server_info.summary.system_info.uuid)),
+        config_template: None,
+        local_context_data: None,
+        tags: None,
+        custom_fields: Some(custom_fields),
+    };
+    
+    if dry_run {
+        println!("DRY RUN: Would create/update device:");
+        println!("{:#?}", device);
+        return Ok(());
+    }
+    
+    let device_id = client.create_or_update_device(&device).await?;
+    println!("Created/updated device {} (ID: {})", device.name, device_id);
+    
+    // Create interfaces and IP addresses
+    let mut primary_ip4_id = None;
+    let mut interface_count = 0;
+    
+    for nic in &server_info.network.interfaces {
+        // Determine if this is a management interface (out-of-band)
+        let is_mgmt = nic.name.contains("ilo") || 
+                     nic.name.contains("idrac") || 
+                     nic.name.contains("ipmi") ||
+                     nic.name.contains("bmc") ||
+                     nic.name.to_lowercase().contains("mgmt");
+        
+        // Enhanced interface type detection
+        let interface_type = match nic.speed.as_ref().map(|s| s.as_str()) {
+            Some(speed) if speed.contains("100000") || speed.contains("100Gb") => "100gbase-x-qsfp28",
+            Some(speed) if speed.contains("40000") || speed.contains("40Gb") => "40gbase-x-qsfpp",
+            Some(speed) if speed.contains("25000") || speed.contains("25Gb") => "25gbase-x-sfp28",
+            Some(speed) if speed.contains("10000") || speed.contains("10Gb") => {
+                if nic.model.to_lowercase().contains("sfp") {
+                    "10gbase-x-sfpp"
+                } else {
+                    "10gbase-t"
+                }
+            },
+            Some(speed) if speed.contains("1000") || speed.contains("1Gb") => "1000base-t",
+            Some(speed) if speed.contains("100") => "100base-tx",
+            _ => "other",
+        };
+        
+        let interface = NetBoxInterface {
+            device: device_id,
+            name: nic.name.clone(),
+            type_: interface_type.to_string(),
+            enabled: true,
+            parent: None,
+            bridge: None,
+            lag: None,
+            mtu: None,
+            mac_address: if nic.mac != "00:00:00:00:00:00" && nic.mac != "Unknown" { 
+                Some(nic.mac.clone()) 
+            } else { 
+                None 
+            },
+            speed: nic.speed.as_ref().and_then(|s| {
+                // Parse various speed formats
+                if s.contains("Gb/s") {
+                    s.trim_end_matches("Gb/s").parse::<u32>().ok().map(|v| v * 1_000_000)
+                } else if s.contains("Mb/s") {
+                    s.trim_end_matches("Mb/s").parse::<u32>().ok().map(|v| v * 1_000)
+                } else {
+                    None
+                }
+            }),
+            duplex: Some("auto".to_string()),
+            wwn: None,
+            mgmt_only: is_mgmt,
+            description: Some(format!("{} {} - PCI: {}", nic.vendor, nic.model, nic.pci_id)),
+            mode: None,
+            rf_role: None,
+            rf_channel: None,
+            poe_mode: None,
+            poe_type: None,
+            rf_channel_frequency: None,
+            rf_channel_width: None,
+            tx_power: None,
+            untagged_vlan: None,
+            tagged_vlans: None,
+            mark_connected: !is_mgmt, // Assume production interfaces are connected
+            cable: None,
+            cable_end: None,
+            wireless_link: None,
+            link_peers: None,
+            link_peers_type: None,
+            wireless_lans: None,
+            vrf: None,
+            tags: None,
+            custom_fields: {
+                let mut cf = HashMap::new();
+                if let Some(numa) = nic.numa_node {
+                    cf.insert("numa_node".to_string(), serde_json::Value::Number(numa.into()));
+                }
+                if cf.is_empty() { None } else { Some(cf) }
+            },
+        };
+        
+        let interface_id = client.create_interface(&interface).await?;
+        println!("Created interface {} (ID: {})", interface.name, interface_id);
+        interface_count += 1;
+        
+        // Create IP addresses for this interface
+        let ips = vec![&nic.ip]; // NetworkInterface has a single ip field, not ips
+        for ip in &ips {
+            if *ip != "127.0.0.1" && !ip.starts_with("::") && !ip.starts_with("fe80:") && *ip != "Unknown" {
+                // Determine subnet mask based on IP class and common patterns
+                let subnet_mask = if ip.starts_with("10.") {
+                    "/8"  // Private Class A
+                } else if ip.starts_with("172.") {
+                    "/12" // Private Class B
+                } else if ip.starts_with("192.168.") {
+                    "/24" // Private Class C
+                } else if ip.starts_with("169.254.") {
+                    "/16" // Link-local
+                } else {
+                    "/24" // Default assumption
+                };
+                
+                let netbox_ip = NetBoxIPAddress {
+                    address: format!("{}{}", ip, subnet_mask),
+                    vrf: None,
+                    tenant: None,
+                    status: "active".to_string(),
+                    role: if is_mgmt { 
+                        Some("vip".to_string()) // Management/OOB IPs are VIPs
+                    } else if interface_count == 1 || nic.name.starts_with("eth0") || nic.name.starts_with("eno1") {
+                        Some("loopback".to_string()) // Primary interface
+                    } else {
+                        Some("secondary".to_string()) // Additional interfaces
+                    },
+                    assigned_object_type: Some("dcim.interface".to_string()),
+                    assigned_object_id: Some(interface_id),
+                    nat_inside: None,
+                    nat_outside: None,
+                    dns_name: if !is_mgmt { Some(server_info.fqdn.clone()) } else { 
+                        Some(format!("{}-{}.{}", server_info.hostname, if is_mgmt { "mgmt" } else { "oob" }, "example.com"))
+                    },
+                    description: Some(format!("{} IP", if is_mgmt { "Out-of-band Management" } else { "Inband Primary" })),
+                    comments: None,
+                    tags: None,
+                    custom_fields: None,
+                };
+                
+                let ip_id = client.create_ip_address(&netbox_ip).await?;
+                println!("Created IP address {} (ID: {})", netbox_ip.address, ip_id);
+                
+                // Set as primary IP if this is the main production interface
+                if !is_mgmt && primary_ip4_id.is_none() && 
+                   (nic.name.starts_with("eth0") || nic.name.starts_with("eno1") || interface_count == 1) {
+                    primary_ip4_id = Some(ip_id);
+                }
+            }
+        }
+    }
+    
+    // Update device with primary IP if found
+    if let Some(primary_ip) = primary_ip4_id {
+        let update_payload = serde_json::json!({
+            "primary_ip4": primary_ip
+        });
+        
+        let update_url = format!("{}/api/dcim/devices/{}/", client.base_url, device_id);
+        let _response = client.client
+            .patch(&update_url)
+            .header("Authorization", format!("Token {}", client.token))
+            .json(&update_payload)
+            .send()
+            .await?;
+        println!("Updated device primary IP");
+    }
+    
+    // Create inventory items for components
+    
+    // CPU inventory items - create one per socket
+    for socket in 0..server_info.summary.cpu_topology.sockets {
+        let cpu_item = NetBoxInventoryItem {
+            device: device_id,
+            parent: None,
+            name: format!("CPU-Socket-{}", socket),
+            label: Some(format!("Socket {}", socket)),
+            role: None,
+            manufacturer: {
+                // Try to extract CPU manufacturer from model
+                let cpu_model = &server_info.summary.cpu_topology.cpu_model;
+                if cpu_model.to_lowercase().contains("intel") {
+                    client.get_or_create_manufacturer("Intel Corporation").await.ok()
+                } else if cpu_model.to_lowercase().contains("amd") {
+                    client.get_or_create_manufacturer("Advanced Micro Devices").await.ok()
+                } else {
+                    Some(manufacturer_id)
+                }
+            },
+            part_id: Some(server_info.summary.cpu_topology.cpu_model.clone()),
+            serial: None,
+            asset_tag: None,
+            discovered: true,
+            description: Some(format!(
+                "{} - {} cores, {} threads per socket",
+                server_info.summary.cpu_topology.cpu_model,
+                server_info.summary.cpu_topology.cores_per_socket,
+                server_info.summary.cpu_topology.cores_per_socket * server_info.summary.cpu_topology.threads_per_core
+            )),
+            component_type: None,
+            component_id: None,
+            tags: None,
+            custom_fields: {
+                let mut cf = HashMap::new();
+                cf.insert("cores_per_socket".to_string(), serde_json::Value::Number(server_info.summary.cpu_topology.cores_per_socket.into()));
+                cf.insert("threads_per_core".to_string(), serde_json::Value::Number(server_info.summary.cpu_topology.threads_per_core.into()));
+                cf.insert("numa_nodes".to_string(), serde_json::Value::Number(server_info.summary.cpu_topology.numa_nodes.into()));
+                Some(cf)
+            },
+        };
+        let cpu_item_id = client.create_inventory_item(&cpu_item).await?;
+        println!("Created CPU inventory item: Socket {} (ID: {})", socket, cpu_item_id);
+    }
+    
+    // Memory inventory items - enhanced with detailed info
+    for dimm in &server_info.hardware.memory.modules {
+        let mem_manufacturer_id = if dimm.manufacturer != "Unknown" && !dimm.manufacturer.is_empty() {
+            client.get_or_create_manufacturer(&dimm.manufacturer).await.unwrap_or(manufacturer_id)
+        } else {
+            manufacturer_id
+        };
+        
+        let mem_item = NetBoxInventoryItem {
+            device: device_id,
+            parent: None,
+            name: format!("Memory-{}", dimm.location),
+            label: Some(dimm.location.clone()),
+            role: None,
+            manufacturer: Some(mem_manufacturer_id),
+            part_id: None, // MemoryModule doesn't have part_number field
+            serial: Some(dimm.serial.clone()),
+            asset_tag: None,
+            discovered: true,
+            description: Some(format!(
+                "{} {} @ {} - {}",
+                dimm.size,
+                dimm.type_,
+                dimm.speed,
+                dimm.location
+            )),
+            component_type: None,
+            component_id: None,
+            tags: None,
+            custom_fields: {
+                let mut cf = HashMap::new();
+                cf.insert("memory_type".to_string(), serde_json::Value::String(dimm.type_.clone()));
+                cf.insert("memory_speed".to_string(), serde_json::Value::String(dimm.speed.clone()));
+                Some(cf)
+            },
+        };
+        let mem_item_id = client.create_inventory_item(&mem_item).await?;
+        println!("Created memory inventory item: {} (ID: {})", dimm.location, mem_item_id);
+    }
+    
+    // Storage inventory items - enhanced with more details
+    for disk in &server_info.hardware.storage.devices {
+        // StorageDevice only has name, type_, size, model fields
+        let storage_manufacturer_id = manufacturer_id; // Use system manufacturer as fallback
+        
+        let storage_item = NetBoxInventoryItem {
+            device: device_id,
+            parent: None,
+            name: format!("Disk-{}", disk.name),
+            label: Some(disk.name.clone()),
+            role: None,
+            manufacturer: Some(storage_manufacturer_id),
+            part_id: Some(disk.model.clone()),
+            serial: None, // Not available in current StorageDevice struct
+            asset_tag: None,
+            discovered: true,
+            description: Some(format!("{} {} - {}", disk.model, disk.size, disk.type_)),
+            component_type: None,
+            component_id: None,
+            tags: None,
+            custom_fields: {
+                let mut cf = HashMap::new();
+                cf.insert("interface_type".to_string(), serde_json::Value::String(disk.type_.clone()));
+                cf.insert("capacity".to_string(), serde_json::Value::String(disk.size.clone()));
+                Some(cf)
+            },
+        };
+        let storage_item_id = client.create_inventory_item(&storage_item).await?;
+        println!("Created storage inventory item: {} (ID: {})", disk.name, storage_item_id);
+    }
+    
+    // GPU inventory items - enhanced with detailed info
+    for (i, gpu) in server_info.hardware.gpus.devices.iter().enumerate() {
+        let gpu_manufacturer_id = if gpu.vendor != "Unknown" && !gpu.vendor.is_empty() {
+            client.get_or_create_manufacturer(&gpu.vendor).await.unwrap_or(manufacturer_id)
+        } else {
+            manufacturer_id
+        };
+        
+        let gpu_item = NetBoxInventoryItem {
+            device: device_id,
+            parent: None,
+            name: format!("GPU-{}", i + 1),
+            label: Some(gpu.name.clone()),
+            role: None,
+            manufacturer: Some(gpu_manufacturer_id),
+            part_id: Some(gpu.pci_id.clone()),
+            serial: None,
+            asset_tag: None,
+            discovered: true,
+            description: Some(format!("{} {} - {} Memory", gpu.vendor, gpu.name, gpu.memory)),
+            component_type: None,
+            component_id: None,
+            tags: None,
+            custom_fields: {
+                let mut cf = HashMap::new();
+                cf.insert("memory_size".to_string(), serde_json::Value::String(gpu.memory.clone()));
+                cf.insert("pci_id".to_string(), serde_json::Value::String(gpu.pci_id.clone()));
+                if let Some(numa) = gpu.numa_node {
+                    cf.insert("numa_node".to_string(), serde_json::Value::Number(numa.into()));
+                }
+                Some(cf)
+            },
+        };
+        let gpu_item_id = client.create_inventory_item(&gpu_item).await?;
+        println!("Created GPU inventory item: {} (ID: {})", gpu.name, gpu_item_id);
+    }
+    
+    // Motherboard inventory item
+    let mb_item = NetBoxInventoryItem {
+        device: device_id,
+        parent: None,
+        name: "Motherboard".to_string(),
+        label: Some("System Board".to_string()),
+        role: None,
+        manufacturer: Some(manufacturer_id),
+        part_id: Some(server_info.summary.motherboard.product_name.clone()),
+        serial: Some(server_info.summary.motherboard.serial.clone()),
+        asset_tag: None,
+        discovered: true,
+        description: Some(format!(
+            "{} {} v{} - {}",
+            server_info.summary.motherboard.manufacturer,
+            server_info.summary.motherboard.product_name,
+            server_info.summary.motherboard.version,
+            server_info.summary.motherboard.type_
+        )),
+        component_type: None,
+        component_id: None,
+        tags: None,
+        custom_fields: {
+            let mut cf = HashMap::new();
+            cf.insert("version".to_string(), serde_json::Value::String(server_info.summary.motherboard.version.clone()));
+            cf.insert("location".to_string(), serde_json::Value::String(server_info.summary.motherboard.location.clone()));
+            Some(cf)
+        },
+    };
+    let mb_item_id = client.create_inventory_item(&mb_item).await?;
+    println!("Created motherboard inventory item (ID: {})", mb_item_id);
+    
+    Ok(())
+}

--- a/src/posting.rs
+++ b/src/posting.rs
@@ -17,7 +17,7 @@ pub struct PostPayload {
 }
 
 pub async fn post_data(
-    data: ServerInfo,
+    data: &ServerInfo,
     labels: HashMap<String, String>,
     endpoint: &str,
     auth_token: Option<&str>,
@@ -26,7 +26,7 @@ pub async fn post_data(
 ) -> Result<(), Box<dyn Error>> {
     let payload = PostPayload {
         labels,
-        result: data,
+        result: data.clone(), // Clone for serialization
     };
 
     // Write payload to file if path is provided


### PR DESCRIPTION
## Summary
- Added new direct flake installation option (Option 3) for Nix users
- Fixed Darwin (macOS) compatibility issues by making Linux-specific tools conditional
- Updated Apple SDK framework references to resolve deprecation warnings

## Changes Made
- **README.md**: Added comprehensive flake installation section with examples
- **flake.nix**: Made runtime dependencies platform-aware (Linux vs Darwin)
- **.envrc**: Suppressed verbose direnv output for cleaner development experience

## Benefits
- Nix users can now install directly with `nix profile install github:sfcompute/hardware_report`
- macOS development environment now works without Linux-specific tool errors
- Cleaner development experience with reduced verbosity

## Test Plan
- [x] Verified flake builds on Darwin (ARM64 macOS)
- [x] Confirmed direnv loads cleanly without errors
- [x] Validated platform-specific dependency handling